### PR TITLE
Server ping computing fix.

### DIFF
--- a/code/server/sv_client.c
+++ b/code/server/sv_client.c
@@ -1440,8 +1440,9 @@ static void SV_UserMove( client_t *cl, msg_t *msg, qboolean delta ) {
 		oldcmd = cmd;
 	}
 
-	// save time for ping calculation
-	cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked = svs.time;
+	// save time for ping calculation, only in the first acknowledge
+	if(cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked < 0)
+		cl->frames[ cl->messageAcknowledge & PACKET_MASK ].messageAcked = Sys_Milliseconds();
 
 	// TTimo
 	// catch the no-cp-yet situation before SV_ClientEnterWorld

--- a/code/server/sv_main.c
+++ b/code/server/sv_main.c
@@ -939,7 +939,8 @@ Updates the cl->ping variables
 static void SV_CalcPings( void ) {
 	int			i, j;
 	client_t	*cl;
-	int			total, count;
+	int			count;
+	float		total;
 	int			delta;
 	playerState_t	*ps;
 
@@ -966,12 +967,12 @@ static void SV_CalcPings( void ) {
 			}
 			delta = cl->frames[j].messageAcked - cl->frames[j].messageSent;
 			count++;
-			total += delta;
+			total += 1.0/(delta+0.1);  // average frequency (avoiding 0 division)
 		}
 		if (!count) {
 			cl->ping = 999;
 		} else {
-			cl->ping = total/count;
+			cl->ping = (float)count/total;  // interval from average frequency
 			if ( cl->ping > 999 ) {
 				cl->ping = 999;
 			}

--- a/code/server/sv_snapshot.c
+++ b/code/server/sv_snapshot.c
@@ -598,7 +598,7 @@ void SV_SendMessageToClient(msg_t *msg, client_t *client)
 	
 	// record information about the message
 	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSize = msg->cursize;
-	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent = svs.time;
+	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageSent = Sys_Milliseconds();
 	client->frames[client->netchan.outgoingSequence & PACKET_MASK].messageAcked = -1;
 
 	// send the datagram


### PR DESCRIPTION
https://github.com/karnute/ioq3/tree/ping_calc

> @karnute
>
> The ping, as seen from the server, is computed from acknowledge time averaged from last 32 messages. Since origins (Quake3) the differences were computed from deltas (between sent and acked) in svs.time, but that time is only increased at each snapshot in server.
> The snapshot increment time is int(1000/sv_fps), as sv_fps is currently locked at 20, the resulting increment is 50ms. Nowadays, latency bellow 50ms is very common.
> Also the acknowledge time was saved every time the message and duplicates were read, resulting in wrong deltas. For clients with a real latency bellow 50 ms, there was always one packet (sent in the same snapshot) with delta=0 and 31 packets with delta=50, so the integer part of the average was always resulting 48 as ping.
> The ping computed for each client is used by the server to apply a lag compensation in the position of other players sent to each client, so the wrong ping could affect the hits.
> Additionally, this patch includes a change in the average of deltas to improve against sporadic sort bursts in latency. This is done by averaging frequency (inverse of delta) and then computing corresponding latency by the inverse of frequency.
>
> As I said above for latency less than 50ms it was stuck in 48 ping. Curiously, it could be less than 48 in some very pathological cases with a lot of lost packets (that will not be counted in the 32 pool) and successive last acks of more than one previous message were arriving with much delay in the same snapshot. This problem is partially solved in my patch by the "if" inserted in line 1497 of code/server/sv_client.c, that avoids other acks after the first to overwrite the real response time (only with that correction, pings below 50ms would show as exact 0 almost always, if the server cpu is not overloaded).
> 
> For any latency greater than 50ms, the variance around mean value was not very important. What previous code measured was only the mean probability of every packet **last** ack arriving in one or other snapshot, and that probability is proportional to the multiple of latency respect to 50ms (think on the integer part of the sum of 32 integers times 50/32). So the average ping value was more or less accurate except for small increase in variance due to the 50/32=1,56 factor increase for a variation of every 1ms (something like if one real variation were +2ms the ping would change +3ms). Also, pathological cases could arise if duplicated packets were traveling by different routes with very different latency (this is avoided again by the "if" in patch). The substitution of svs.time by Sys_Milliseconds() solves the overall inaccuracy and at the same time (and more important) it solves the problem for real latency below 50ms (or any other snapshot time from sv_fps).
> 
> Finally, using an average of time intervals has the problem of the great influence of sort bursts of delays in networks (large spikes). To address this problem, it is usual to average the frequency instead of intervals, and convert average frequency into latency again by the inverse.
> 
> There is a marginally residual of error in the network latency estimation. It is the average time spent by a busy client to acknowledge a message. Although, this is not relevant for UrT, as that time will be what the client is really taking to "see" messages from server snapshot. The client is only listening to network messages during the free time in each frame. If the client spend almost all frame time (= int(1000/com_maxfps), usually 8ms) to render the frame, then it will only listen network in one short point every frame. So, usually a busy client will add an average of 4ms. to its response time, and that number is exactly what I found in my localhost tests (dedicated server) with simulated latency.